### PR TITLE
add apt libgl1-mesa-glx for openCV, add graphviz, remove jupyter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 FROM ubuntu:18.04
 
 RUN apt-get update && \
-apt-get install -y wget
-
+apt-get install -y wget libgl1-mesa-glx
 
 RUN wget https://repo.anaconda.com/archive/Anaconda3-5.1.0-Linux-x86_64.sh
 
@@ -12,7 +11,7 @@ RUN chmod +x Anaconda3-5.1.0-Linux-x86_64.sh && \
 ENV PATH="/opt/Anaconda3/bin:${PATH}"
 
 RUN conda update -n base conda && \
-conda install --yes -c conda-forge opencv matplotlib jupyter
+conda install --yes -c conda-forge opencv matplotlib python-graphviz
 
 EXPOSE 8888
 


### PR DESCRIPTION
Yo Thibaut, en ajoutant la librairie libgl1-mesa-glx, OpenCV fonctionne maintenant pour moi. aussi, Jupyter downgrade quand tu l'installe, donc c'est mieux de laisser la version qui s'installe par défaut. Et j'ai ajouté graphviz, on en a besoin pour les exercices du decision tree dans le cours. :)